### PR TITLE
add message format when create message from pdu

### DIFF
--- a/app/src/main/java/me/drakeet/inmessage/service/SMSBroadcastReceiver.java
+++ b/app/src/main/java/me/drakeet/inmessage/service/SMSBroadcastReceiver.java
@@ -28,9 +28,10 @@ public class SMSBroadcastReceiver extends BroadcastReceiver {
     public void onReceive(Context context, Intent intent) {
         //从Intent中接受信息
         Object[] pdus = (Object[]) intent.getExtras().get("pdus");
+		String format = intent.getStringExtra("format");
         for (Object p : pdus) {
             byte[] sms = (byte[]) p;
-            SmsMessage message = SmsMessage.createFromPdu(sms);
+            SmsMessage message = (format != null) ? SmsMessage.createFromPdu(sms, format) : SmsMessage.createFromPdu(sms);
             //获取短信内容
             final String content = message.getMessageBody();
             //获取发送时间


### PR DESCRIPTION
SmsMessage createFromPdu(byte[] pdu) will soon be deprecated by Google, and all applications which handle incoming SMS messages by processing the {@code SMS_RECEIVED_ACTION} broadcast  intent <b>must</b> now pass the new {@code format} String extra from the intent into the new method {@code createFromPdu(byte[], String)} which takes an extra format parameter.  
Use createFromPdu(byte[] pdu) will cause exception for sim 2 in multi sim mobile device.
Signed-off-by: dxjia <piggyguy@sina.cn>